### PR TITLE
perf: increase follows fetched to 100 per request

### DIFF
--- a/src/algos/after-dark.ts
+++ b/src/algos/after-dark.ts
@@ -37,6 +37,7 @@ export const handler = async (ctx: AppContext, params: QueryParams, agent: BskyA
 
         const res = await agent.api.app.bsky.graph.getFollows({
           actor: requesterDID,
+          limit: 100, // default 50, max 100
           ... (req_cursor !== null ? { ['cursor']: req_cursor } : {})
         })
 


### PR DESCRIPTION
Increases the number of follows fetched in each request from the default 50 to the max of 100.

Testing against my profile with around 850 followers, this reduced fetching follows from ~3.5s to ~2s 

It may be worth caching these responses or storing follows in the db to avoid querying the bsky api each time the feed is requested