### PR TITLE
perf: compound index to cover getLatestPostsForTag

### DIFF
--- a/src/db/dbClient.ts
+++ b/src/db/dbClient.ts
@@ -25,6 +25,7 @@ export class dbSingleton {
     await postCollection.createIndex({ labels: 1 });
     await postCollection.createIndex({ "embed.images": 1 });
     await postCollection.createIndex({ "embed.media": 1 });
+    await postCollection.createIndex({ labels: 1, author: 1, indexedAt: -1, cid: -1 });
   }
 
   // clears database


### PR DESCRIPTION
Adds a compound index to cover the current query used in getLatestPostsForTag for the AD feed.

I don't have a properly populated local db to be able to test this against to get any sort of useful timings.

Looking at the winning schema plan for the request in its current form, with the way the indexes have been setup against individual fields when the query is made for this

```
{
  labels: {
    $in: ['porn', 'nudity', 'sexual', 'underwear'],
    $ne: null,
  },
  author: {
    $in: authors
  }
}
```

mongo is only utilising the index for the labels field.

This compound index should give some peformance improvement by covering the whole query plus the sorting. Hopefully you have a staging or test envrionment to try this out against first to see if it does actually give any meaninful speed up.